### PR TITLE
Deprecate API schemaversion 1

### DIFF
--- a/java-client/src/main/java/org/eclipse/ditto/examples/changes/RegisterForChanges.java
+++ b/java-client/src/main/java/org/eclipse/ditto/examples/changes/RegisterForChanges.java
@@ -12,16 +12,11 @@
  */
 package org.eclipse.ditto.examples.changes;
 
-import static org.eclipse.ditto.model.things.ThingsModelFactory.allPermissions;
-
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.ditto.client.DittoClient;
 import org.eclipse.ditto.client.changes.ChangeAction;
@@ -30,7 +25,6 @@ import org.eclipse.ditto.examples.common.ExamplesBase;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
-import org.eclipse.ditto.model.things.AclEntry;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingId;
 import org.slf4j.Logger;
@@ -69,6 +63,10 @@ public final class RegisterForChanges extends ExamplesBase {
 
     public static void main(final String... args) {
         new RegisterForChanges();
+    }
+
+    private static String registrationId() {
+        return "registration:" + UUID.randomUUID();
     }
 
     /**
@@ -110,12 +108,8 @@ public final class RegisterForChanges extends ExamplesBase {
     private void createThing(final DittoClient client, final AuthorizationSubject... subjects) {
         LOGGER.info("Create thing {} and set required permissions.", thingId);
 
-        final Set<AclEntry> aclEntries = Stream.of(subjects)
-                .map(subject -> AclEntry.newInstance(subject, allPermissions()))
-                .collect(Collectors.toSet());
         final Thing thing = Thing.newBuilder()
                 .setId(thingId)
-                .setPermissions(aclEntries)
                 .build();
 
         try {
@@ -140,10 +134,6 @@ public final class RegisterForChanges extends ExamplesBase {
         }
         LOGGER.info("All changes received: {}", allMessagesReceived);
         terminate();
-    }
-
-    private static String registrationId() {
-        return "registration:" + UUID.randomUUID();
     }
 
 }

--- a/java-client/src/main/java/org/eclipse/ditto/examples/common/ExamplesBase.java
+++ b/java-client/src/main/java/org/eclipse/ditto/examples/common/ExamplesBase.java
@@ -53,10 +53,9 @@ import com.neovisionaries.ws.client.WebSocket;
 public abstract class ExamplesBase {
 
     private static final ConfigProperties CONFIG_PROPERTIES = ConfigProperties.getInstance();
-
-    protected AuthorizationSubject authorizationSubject;
     protected final DittoClient client1;
     protected final DittoClient client2;
+    protected AuthorizationSubject authorizationSubject;
 
     protected ExamplesBase() {
         client1 = buildClient();
@@ -81,7 +80,7 @@ public abstract class ExamplesBase {
 
         final MessagingConfiguration.Builder messagingConfigurationBuilder =
                 WebSocketMessagingConfiguration.newBuilder()
-                        .jsonSchemaVersion(JsonSchemaVersion.V_1)
+                        .jsonSchemaVersion(JsonSchemaVersion.V_2)
                         .reconnectEnabled(false)
                         .endpoint(CONFIG_PROPERTIES.getEndpointOrThrow());
 
@@ -186,5 +185,6 @@ public abstract class ExamplesBase {
         client1.destroy();
         client2.destroy();
     }
+
 
 }

--- a/java-client/src/main/java/org/eclipse/ditto/examples/live/RegisterForAndEmitLiveEvents.java
+++ b/java-client/src/main/java/org/eclipse/ditto/examples/live/RegisterForAndEmitLiveEvents.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.examples.live;
 
-import static org.eclipse.ditto.model.things.ThingsModelFactory.allPermissions;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +63,6 @@ public class RegisterForAndEmitLiveEvents extends ExamplesBase {
         client1.twin().create(thingId).thenCompose(created -> {
             final Thing updated =
                     created.toBuilder()
-                            .setPermissions(authorizationSubject, allPermissions())
                             .build();
             return client1.twin().update(updated);
         }).get(2, TimeUnit.SECONDS);

--- a/java-client/src/main/java/org/eclipse/ditto/examples/live/RegisterForAndSendLiveCommands.java
+++ b/java-client/src/main/java/org/eclipse/ditto/examples/live/RegisterForAndSendLiveCommands.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.examples.live;
 
-import static org.eclipse.ditto.model.things.ThingsModelFactory.allPermissions;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -59,11 +57,10 @@ public class RegisterForAndSendLiveCommands extends ExamplesBase {
     }
 
     private void registerForAndSendLiveCommands() throws InterruptedException, TimeoutException, ExecutionException {
-        LOGGER.info("[AT BACKEND] create a Thing with required permissions: {}", thingId);
+        LOGGER.info("[AT BACKEND] create a Thing: {}", thingId);
         client1.twin().create(thingId).thenCompose(created -> {
             final Thing updated =
                     created.toBuilder()
-                            .setPermissions(authorizationSubject, allPermissions())
                             .setFeature(ThingsModelFactory.newFeature(FEATURE_ID))
                             .build();
             return client1.twin().update(updated);

--- a/java-client/src/main/java/org/eclipse/ditto/examples/manage/ManageThings.java
+++ b/java-client/src/main/java/org/eclipse/ditto/examples/manage/ManageThings.java
@@ -27,7 +27,6 @@ import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.Feature;
-import org.eclipse.ditto.model.things.Permission;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.model.things.ThingsModelFactory;
@@ -91,7 +90,7 @@ public class ManageThings extends ExamplesBase {
     }
 
     /**
-     * Creates a complex {@code Thing} object with {@code ACL}s, {@code Feature}s, and {@code Attribute}s, and waits for
+     * Creates a complex {@code Thing} object with {@code Policy}s, {@code Feature}s, and {@code Attribute}s, and waits for
      * a success or failure result.
      *
      * @throws ExecutionException if a failure response is received for the requests, or if an exception occurs inside
@@ -102,11 +101,10 @@ public class ManageThings extends ExamplesBase {
      */
     private void createAComplexThing() throws InterruptedException, ExecutionException, TimeoutException {
         LOGGER.info("Starting: createAComplexThing()");
-        /* Create a new thing with acls, features, attributes and define handlers for success and failure */
+        /* Create a new thing with policy, features, attributes and define handlers for success and failure */
         client1.twin().create(complexThingId).thenCompose(created -> {
             final Thing updated =
                     created.toBuilder()
-                            .setPermissions(authorizationSubject, ThingsModelFactory.allPermissions())
                             .setFeatureProperty("featureId", JsonFactory.newPointer("propertyName"),
                                     JsonFactory.newValue("value"))
                             .setAttribute(JsonFactory.newPointer("attributeName"), JsonFactory.newValue("value"))
@@ -169,7 +167,6 @@ public class ManageThings extends ExamplesBase {
         final JsonValue attributeJsonValue = JsonFactory.newValue("bar");
         final Thing thing = ThingsModelFactory.newThingBuilder()
                 .setId(thingId)
-                .setPermissions(authorizationSubject, ThingsModelFactory.allPermissions())
                 .setAttribute(attributeJsonPointer, attributeJsonValue)
                 .build();
 

--- a/java-client/src/main/java/org/eclipse/ditto/examples/messages/RegisterForAndSendMessages.java
+++ b/java-client/src/main/java/org/eclipse/ditto/examples/messages/RegisterForAndSendMessages.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.examples.messages;
 
-import static org.eclipse.ditto.model.things.AccessControlListModelFactory.allPermissions;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -30,7 +28,6 @@ import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingId;
-import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +64,6 @@ public final class RegisterForAndSendMessages extends ExamplesBase {
             client1.twin().create(fromThingId)
                     .thenCompose(created -> {
                         final Thing updated = created.toBuilder()
-                                .setPermissions(authorizationSubject, allPermissions())
                                 .build();
                         return client1.twin().update(updated);
                     }).get(10, TimeUnit.SECONDS);
@@ -77,7 +73,6 @@ public final class RegisterForAndSendMessages extends ExamplesBase {
             client1.twin().create(toThingId)
                     .thenCompose(created -> {
                         final Thing updated = created.toBuilder()
-                                .setPermissions(authorizationSubject, ThingsModelFactory.allPermissions())
                                 .build();
                         return client1.twin().update(updated);
                     }).get(10, TimeUnit.SECONDS);

--- a/java-client/src/main/resources/config.properties
+++ b/java-client/src/main/resources/config.properties
@@ -1,6 +1,6 @@
 ## Required configuration properties
 namespace=org.eclipse.ditto
-endpoint=ws://ditto.eclipse.org
+endpoint=ws://ditto.eclipse.org:8080/ws/2
 ## Authentication properties - choose one
 ### Basic
 #username=


### PR DESCRIPTION
Refactored examples to use commands and models of API version 2 instead of deprecated API version 1.