### PR TITLE
use \u0027 instead of '

### DIFF
--- a/mqtt-bidirectional/README.md
+++ b/mqtt-bidirectional/README.md
@@ -287,7 +287,7 @@ function mapToDittoProtocolMsg(headers, textPayload, bytePayload, contentType) {
             "mappingContext": {
                 "mappingEngine": "JavaScript",
                 "options": {
-                    "incomingScript": "function mapToDittoProtocolMsg(headers, textPayload, bytePayload, contentType) {const jsonString = String.fromCharCode.apply(null, new Uint8Array(bytePayload));const jsonData = JSON.parse(jsonString); const thingId = jsonData.thingId.split(':'); const value = { temp_sensor: { properties: { value: jsonData.temp } },altitude:        {            properties:            {                value: jsonData.alt            }        }    };    return Ditto.buildDittoProtocolMsg(thingId[0], thingId[1], 'things', 'twin', 'commands', 'modify', '/features', headers, value);}"
+                    "incomingScript": "function mapToDittoProtocolMsg(headers, textPayload, bytePayload, contentType) {const jsonString = String.fromCharCode.apply(null, new Uint8Array(bytePayload));const jsonData = JSON.parse(jsonString); const thingId = jsonData.thingId.split(\u0027:\u0027); const value = { temp_sensor: { properties: { value: jsonData.temp } },altitude:        {            properties:            {                value: jsonData.alt            }        }    };    return Ditto.buildDittoProtocolMsg(thingId[0], thingId[1], \u0027things\u0027, \u0027twin\u0027, \u0027commands\u0027, \u0027modify\u0027, \u0027/features\u0027, headers, value);}"
                 }
             }
         }


### PR DESCRIPTION
Using the given script in the example will result in error when create a connection to a mqtt broker. With the modification, the connection can be successfully created and the mqtt message can be mapped to the feature values. 