### PR TITLE
Fix java-client examples dependencies

### DIFF
--- a/java-client/pom.xml
+++ b/java-client/pom.xml
@@ -24,8 +24,7 @@
         <dependency>
             <groupId>org.eclipse.ditto</groupId>
             <artifactId>ditto-client</artifactId>
-            <!-- TODO adapt after release 1.0.0-M2 -->
-            <version>0-SNAPSHOT</version>
+            <version>1.1.2</version>
         </dependency>
 
         <dependency>
@@ -51,6 +50,21 @@
             <version>3.12.2</version>
             <scope>provided</scope>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Added newest version of ditto java-client to examples and jaxb.
Signed-off-by: David Schwilk <david.schwilk@bosch.io>