### PR TITLE
fixed connection feedback loop in mqtt-quick-introduction

### DIFF
--- a/mqtt-quick-introduction/README.md
+++ b/mqtt-quick-introduction/README.md
@@ -262,7 +262,6 @@ Now we need to configure target connection. Create connection_target.json file w
             "targets": [{
                 "address": "my.sensors.notifications/{{ thing:id }}",
                 "topics": [
-                    "_/_/things/twin/events",
                     "_/_/things/live/messages"
                 ],
                 "authorizationContext": ["ditto:observer"],


### PR DESCRIPTION
Ditto publishing twin update events back to MQTT causing an infinite feedback loop.
https://github.com/user-attachments/assets/a398aef6-0ea4-481e-9bb0-dc406055fa2b

Fix:
The "_/_/things/live/events" topic removed from connection_target.json